### PR TITLE
Replace iteritems into items to support Python3

### DIFF
--- a/templates/yum-cron-hourly.conf.j2
+++ b/templates/yum-cron-hourly.conf.j2
@@ -2,7 +2,7 @@
 
 {% for section in yum_cron_hourly|sort %}
 [{{ section }}]
-{%   for key, value in yum_cron_hourly[section].iteritems()|sort %}
+{%   for key, value in yum_cron_hourly[section].items()|sort %}
 {%     if value is sameas true %}
 {{ key }} = yes
 {%     elif value is sameas false %}

--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -2,7 +2,7 @@
 
 {% for section in yum_cron|sort %}
 [{{ section }}]
-{%   for key, value in yum_cron[section].iteritems()|sort %}
+{%   for key, value in yum_cron[section].items()|sort %}
 {%     if value is sameas true %}
 {{ key }} = yes
 {%     elif value is sameas false %}


### PR DESCRIPTION
This PR fixes the error below occured in Python 3:

```
failed: [cabernet-staging-bastion-provisioner] (item={'src': 'yum-cron.conf.j2', 'dst': '/etc/yum/yum-cron.conf'}) => {"changed": false, "item": {"dst": "/etc/yum/yum-cron.conf", "src": "yum-cron.conf.j2"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}
failed: [cabernet-staging-bastion-provisioner] (item={'src': 'yum-cron-hourly.conf.j2', 'dst': '/etc/yum/yum-cron-hourly.conf'}) => {"changed": false, "item": {"dst": "/etc/yum/yum-cron-hourly.conf", "src": "yum-cron-hourly.conf.j2"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}
```

The problem is because `iteritems` is not supported in Python 3, looks like the same reason as https://github.com/linuxhq/ansible-role-chrony/pull/2 .

I replaced it into `items`, then the above error was not occured.